### PR TITLE
widget hook : useShowPhotosEditor

### DIFF
--- a/src/widgets/profile-photos-editor/index.ts
+++ b/src/widgets/profile-photos-editor/index.ts
@@ -1,1 +1,3 @@
+export { useShowPhotosEditor } from './model/useShowPhotosEditor';
+
 export { default as ProfilePhotosEditor } from './ui/ProfilePhotosEditor';

--- a/src/widgets/profile-photos-editor/model/useShowPhotosEditor.tsx
+++ b/src/widgets/profile-photos-editor/model/useShowPhotosEditor.tsx
@@ -1,0 +1,30 @@
+import { useModalController } from '@entities/modal';
+import ProfilePhotosEditor from '../ui/ProfilePhotosEditor';
+
+type ShowPhotosEditorHandler = (userId: string) => void;
+const TITLE = 'Profile images editor';
+
+/**
+ * A custom hook that provides functionality to display a modal for editing profile photos.
+ *
+ * @function
+ * @returns {Object} An object containing the `showPhotosEditor` function - a handler function to show the photo editor modal.
+ *
+ * The `showPhotosEditor` function takes a user ID as an argument and displays a modal with
+ * the `ProfilePhotosEditor` component as its content.
+ */
+
+export const useShowPhotosEditor = (): {
+  showPhotosEditor: ShowPhotosEditorHandler;
+} => {
+  const { showModal } = useModalController();
+
+  const showPhotosEditor: ShowPhotosEditorHandler = (userId) => {
+    showModal({
+      title: TITLE,
+      content: <ProfilePhotosEditor userId={userId} />,
+    });
+  };
+
+  return { showPhotosEditor };
+};


### PR DESCRIPTION
Created useShowPhotosEditor hook that provides functionality to display a modal for editing profile photos.
The hook returns an object containing the 'showPhotosEditor' function - a handler function to show the photo editor modal.

The 'showPhotosEditor' function takes a user ID as an argument and displays a modal with the 'ProfilePhotosEditor' component as its content.